### PR TITLE
PLAT-997 - JSON/HStore checker

### DIFF
--- a/src/list.cpp
+++ b/src/list.cpp
@@ -61,7 +61,7 @@ void CheckJSONValuedAttribute(Configuration& state,
   if(ddl_statement == false){
     return;
   }
-  std::regex pattern("(\\s+hstore\\s+)|(\\s+json\\s+)");
+  std::regex pattern("(\\s+hstore)|(\\s+json)|(\\s+jsonb)");
   std::string title = "JSON- or HStore-Valued Attribute";
   PatternType pattern_type = PatternType::PATTERN_TYPE_LOGICAL_DATABASE_DESIGN;
 


### PR DESCRIPTION
Original code did not consider cases where datatype is followed by non-numeric character (e.g.,
`...col1 as json, col2 as ...`)